### PR TITLE
Fix spelling error: doesnt' -> doesn't

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -599,7 +599,7 @@ for 2-D plots.  The C<zlabel> works for 3-D plots.  The C<cblabel> option
 sets the label for the color box, in plot types that have one (e.g.
 image display).
 
-(Don't be confused by C<clabel>, which doesnt' set a label at all, rather
+(Don't be confused by C<clabel>, which doesn't set a label at all, rather
 specifies the printf format used by contour labels in contour plots.)
 
 C<key> controls where the plot key (that relates line/symbol style to label)

--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -664,7 +664,7 @@ for 2-D plots.  The C<zlabel> works for 3-D plots.  The C<cblabel> option
 sets the label for the color box, in plot types that have one (e.g.
 image display).
 
-(Don't be confused by C<clabel>, which doesnt' set a label at all, rather
+(Don't be confused by C<clabel>, which doesn't set a label at all, rather
 specifies the printf format used by contour labels in contour plots.)
 
 C<key> controls where the plot key (that relates line/symbol style to label)


### PR DESCRIPTION
The spelling error was reported by the lintian QA tool for the Debian package build.