### PR TITLE
avoid the unsetting of the timeout parameter

### DIFF
--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -2301,7 +2301,7 @@ FOO
 	    # Although 'output' is strictly speaking a terminal option, gnuplot treats it as a plot option -- so
 	    # we copy it into the main plot options hash to be emitted as part of the plot operation.
 	    $this->{options}->{output} = $termOptions->{output};
-	    $this->{wait} = $termOptions->{wait};
+	    $this->{wait} = $termOptions->{wait} if defined $termOptions->{wait};
 	    delete $termOptions->{output};
 
 	    ## Emit the terminal options line for this terminal.


### PR DESCRIPTION
Hi Craig,

I have this software package that uses P::G::G for making plots.  I am trying to test it over a chain of `ssh -X` connections.  It turns out to take longer than 10 seconds for the instance of gnuplot on the remote machine to finish talking to the terminal on the local machine. 

It is not currently possible to simply set the `wait` parameter once and be done with it because each time the `output` method is called, the `wait` parameter is set to undef unless it is explicitly set in each call to `output`.

The suggested change only resets `wait` if it is explicitly reset in the call to `output`.  This makes it possible to set the timeout once and be done.

You might want to consider making similar checks for all the other parameters set in the `output` method, for example in the line directly above the one I changed and the ones below.  `wait` was the one giving me trouble, so that's the only one included in this tiny PR.

Cheers,
B
