### PR TITLE
Fix typo in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -70,7 +70,7 @@ WriteMakefile(
     ),
     MIN_PERL_VERSION          => 5.006,
     CONFIGURE_REQUIRES => {
-        'ExtUtils::Makemaker' => 6.48,
+        'ExtUtils::MakeMaker' => 6.48,
     },
     PREREQ_PM => { 
         'Alien::Gnuplot'      => 0,


### PR DESCRIPTION
I just found this when installing the new release on windows with Strawberry perl 5.20:

! Finding ExtUtils::Makemaker (6.48) on mirror http://www.cpan.org failed.
! Couldn't find module or a distribution ExtUtils::Makemaker (6.48)
! Installing the dependencies failed: Missing version info for module 'ExtUtils::Makemaker'
! Bailing out the installation for PDL-Graphics-Gnuplot-2.008.

Full build log:
https://ci.appveyor.com/project/amba/lab-measurement/build/1.0.27/job/fqxs1ir5xqs1x5mc