### PR TITLE
Fix #65: No quoting for output filenames.

### DIFF
--- a/lib/PDL/Graphics/Gnuplot.pm
+++ b/lib/PDL/Graphics/Gnuplot.pm
@@ -5188,6 +5188,7 @@ our $pOptionsTable =
 			  if($vv ne $v) {
 			      carp "INFO: Plotting to '$vv'\n";
 			  }
+			  $vv = quote_escape($vv);
 			  return "set $k \"$vv\"\n";
 		    },
 		    undef,3,


### PR DESCRIPTION
Insert missing call to quote_escape (escape backslashes and such for gnuplot
double-quote strings).